### PR TITLE
Allow rvm install to overwrite the system path with force

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,6 +4,7 @@ galaxy_info:
   description: The official RVM role to install and manage your ruby versions
   license: MIT
   min_ansible_version: 2.4
+  role_name: rvm.ruby
 
   platforms:
     - name: Debian

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -45,6 +45,7 @@
 - name: Symlink ruby related binaries on the system path
   file:
     state: 'link'
+    force: True
     src: '{{ rvm1_install_path }}/wrappers/default/{{ item }}'
     dest: '{{ rvm1_symlink_to }}/{{ item }}'
     owner: '{{ root_user }}'
@@ -55,6 +56,7 @@
 - name: Symlink bundler binaries on the system path
   file:
     state: 'link'
+    force: True
     src: '{{ rvm1_install_path }}/wrappers/default/{{ item }}'
     dest: '{{ rvm1_symlink_to }}/{{ item }}'
     owner: '{{ root_user }}'


### PR DESCRIPTION
This is when the symlinks already exist, say from an install of ruby from source
and you want to replace it with rvm. It's a hack, for sure, as the clean solution
is to remove/wipe out any source of ruby from the target system before we install
rvm.